### PR TITLE
performance: tunning env vars for calc libs and opencv

### DIFF
--- a/mediapipe_apiserver/cmd/main.py
+++ b/mediapipe_apiserver/cmd/main.py
@@ -1,3 +1,14 @@
+# performance tuning
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+
+import cv2
+cv2.setNumThreads(0)
+
 import click
 
 from mediapipe_apiserver.camera import KinectCamera 

--- a/playground/test_local_camera_async.py
+++ b/playground/test_local_camera_async.py
@@ -3,7 +3,15 @@
 - run capture/detector in sync mode
 - display annotated images with opencv
 """
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+
 import cv2
+cv2.setNumThreads(0)
 
 import sys
 sys.path.append('./')


### PR DESCRIPTION
On Ubuntu 24.04 with 5800X and 4080, zed2 cam, rtmo models can run stably at 60 fps with this commit.